### PR TITLE
Release of new version 1.1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,23 @@
+11/06/2019 19:17  1.1.0  Internal code refactoring
+b259dc9 [BUILD] Replaced deprecated "weak_vendors" option (#6)
+4bbc0de Added GitHub sponsoring information (#5)
+831d609 Fixed CS (#4)
+849fc73 [BUILD] Updated build tools
+b244a0c [BUILD] Removed dependency stage from build matrix
+f695a44 [TEST] Increased test coverage
+4745976 [PATCH] Added FormExtension::getExtendedType method as a symfony BC layer
+f3fc549 [TEST] Fixed CS
+26bccbf [TEST] Fixed CS
+c6ffc14 [TEST] Increased test coverage
+7757c6c [PATCH] Minor internal code refactoring
+220e038 [PATCH] Removed impossible code
+b56c02d [PATCH] Fixed CS
+1355638 [BUILD] Fixed CS
+35cc54a [MINOR] Made min and max time optional for SessionTimeProvider
+0a0254f [BUILD] Removed current copyright date
+a2e2a64 [BUILD] Cleanup phpstan errors
+8e79a89 [BUILD] Added more tests
+d5a24a2 [BUILD] Added more tests
 17/03/2019 17:17  1.0.0  First stable
 7699061 [BUILD] Added weak_vendors when calling phpunit
 dac9fdd [PATCH] Updated CS Fixer config and run


### PR DESCRIPTION
b259dc9 [BUILD] Replaced deprecated "weak_vendors" option (#6)
4bbc0de Added GitHub sponsoring information (#5)
831d609 Fixed CS (#4)
849fc73 [BUILD] Updated build tools
b244a0c [BUILD] Removed dependency stage from build matrix
f695a44 [TEST] Increased test coverage
4745976 [PATCH] Added FormExtension::getExtendedType method as a symfony BC layer
f3fc549 [TEST] Fixed CS
26bccbf [TEST] Fixed CS
c6ffc14 [TEST] Increased test coverage
7757c6c [PATCH] Minor internal code refactoring
220e038 [PATCH] Removed impossible code
b56c02d [PATCH] Fixed CS
1355638 [BUILD] Fixed CS
35cc54a [MINOR] Made min and max time optional for SessionTimeProvider
0a0254f [BUILD] Removed current copyright date
a2e2a64 [BUILD] Cleanup phpstan errors
8e79a89 [BUILD] Added more tests
d5a24a2 [BUILD] Added more tests