### PR TITLE
Enhancement: Use ergebnis/composer-normalize instead of localheinz/composer-normalize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.3",
-    "localheinz/composer-normalize": "^1.3",
+    "ergebnis/composer-normalize": "^2.0.1",
     "symfony/browser-kit": "^4.4 || ^5.0",
     "symfony/translation": "^4.2 || ^5.0",
     "symfony/twig-bundle": "^4.2 || ^5.0"


### PR DESCRIPTION
This PR

* [x] uses `ergebnis/composer-normalize` instead of `localheinz/composer-normalize`

💁‍♂ For reference, see https://localheinz.com/blog/2019/12/10/from-localheinz-to-ergebnis/.